### PR TITLE
fix: exibe campo de observacao obrigatoriamente para revisores ao fin…

### DIFF
--- a/modules/sap/controllers/remoteSapCtrl.py
+++ b/modules/sap/controllers/remoteSapCtrl.py
@@ -149,10 +149,10 @@ class RemoteSapCtrl(SapCtrl):
         self.reportErrorDialog.reported.connect(callback)
         return self.reportErrorDialog.show()
 
-    #mostrar nova parte apenas quando etapaId 2 e 5
+    #Exibe campo de observação para: Revisão (2), Revisão final (5) e  Revisão/Correção (4) (neste caso fica na propria atv) 
     def showEndActivityDialog(self, withoutCorrection, stepTypeId):
-        activeObs = stepTypeId in [2,5]
-        endActivityDialog = self.guiFactory.createEndActivityDialog(self, activeObs)
+        activeObs = stepTypeId in [2, 4, 5]
+        endActivityDialog = self.guiFactory.createEndActivityDialog(self, activeObs, stepTypeId)
         endActivityDialog.setWithoutCorrection(withoutCorrection)
         return endActivityDialog.exec_() == QtWidgets.QDialog.Accepted
         

--- a/modules/sap/factories/endActivityDialogSingleton.py
+++ b/modules/sap/factories/endActivityDialogSingleton.py
@@ -7,5 +7,6 @@ class EndActivityDialogSingleton:
     @staticmethod
     def getInstance(*args):
         if not EndActivityDialogSingleton.dialog:
+            EndActivityDialogSingleton.dialog.close()
             EndActivityDialogSingleton.dialog = EndActivityDialog(*args)
         return EndActivityDialogSingleton.dialog

--- a/modules/sap/factories/guiFactory.py
+++ b/modules/sap/factories/guiFactory.py
@@ -7,5 +7,5 @@ class GUIFactory:
     def createReportErrorDialog(self, controller, qgis):
         return ReportErrorDialog(controller, qgis)
 
-    def createEndActivityDialog(self, controller, activeObs):
-        return EndActivityDialogSingleton.getInstance(controller, activeObs)
+    def createEndActivityDialog(self, controller, activeObs, stepTypeId=None):
+        return EndActivityDialogSingleton.getInstance(controller, activeObs, stepTypeId)

--- a/modules/sap/widgets/endActivityDialog.py
+++ b/modules/sap/widgets/endActivityDialog.py
@@ -4,17 +4,33 @@ from SAP_Operador.modules.sap.widgets.sapDialog import SapDialog
 
 class EndActivityDialog(SapDialog):
 
-    def __init__(self, controller=None, activeObs=False):
+    def __init__(self, controller=None, activeObs=False, stepTypeId=None):
         super(EndActivityDialog, self).__init__()
         uic.loadUi(self.getUiPath(), self)
         self.controller = controller
+        self.activeObs = activeObs
+        self.stepTypeId = stepTypeId
         self.endBtn.setEnabled(False)
         self.nameLe.textEdited.connect(self.updateEndButton)
         self.withoutCorrection = False
         self.activityDataModel = self.controller.getActivityDataModel()
-        stepTypeId = self.activityDataModel.getStepTypeId()
         self.revisionW.setVisible(activeObs)
-        self.resize(502, 141)
+        if activeObs:
+            # tipo_etapa_id = 4 (Revisão/Correção): obs fica na própria atividade
+            if stepTypeId == 4:
+                self.label_3.setText(
+                    '<html><head/><body><p>Observação desta atividade '
+                    '<span style="font-weight:600;">(Opcional)</span>:</p></body></html>'
+                )
+            else:
+                # tipo_etapa_id 2/5: obs vai para próxima atividade de correção
+                self.label_3.setText(
+                    '<html><head/><body><p>Observação para a próxima atividade de correção '
+                    '<span style="font-weight:600;">(Opcional)</span>:</p></body></html>'
+                )
+            self.resize(502, 280)
+        else:
+            self.resize(502, 141)
 
     def setController(self, controller):
         self.controller = controller
@@ -43,9 +59,14 @@ class EndActivityDialog(SapDialog):
         }
         if self.changeFlowCb.currentIndex() != 0:
             data['alterar_fluxo'] = self.changeFlowCb.currentText()
-        obs = self.obsTe.toPlainText()
+        obs = self.obsTe.toPlainText().strip()
         if obs:
-            data['observacao_proxima_atividade'] = obs
+            if self.stepTypeId == 4:
+                # Revisão/Correção: salva observação na própria atividade
+                data['observacao_atividade'] = obs
+            else:
+                # Revisão / Revisão final: envia para próxima atividade de correção
+                data['observacao_proxima_atividade'] = obs
         return data
 
     @QtCore.pyqtSlot(bool)


### PR DESCRIPTION
Objetivo:

Garantir que o campo de observação seja **sempre exibido** ao revisor ao finalizar uma atividade, com comportamento distinto conforme o tipo de etapa:

- Corrigir bug do ->  
Em : . `modules/sap/factories/endActivityDialogSingleton.py`

Adicionar  EndActivityDialogSingleton.dialog.close()

---

Persistencia do stepTypeId 

---- 
Mudar comportamento do dialogo "observações" 

- Revisão (`tipo_etapa_id = 2`) e Revisão final (`tipo_etapa_id = 5`):** campo exibido; observação enviada para a **próxima atividade** da mesma unidade de trabalho/subfase (para o corretor).

- Revisão/Correção (`tipo_etapa_id = 4`):** campo exibido; observação salva na **própria atividade**.
( Alteração necessaria no sap tambem)

- Execução (`tipo_etapa_id = 1`) e Correção (`tipo_etapa_id = 3`):** campo **não exibido** (sem alteração de comportamento).



| Repositório   | Arquivo                                                   | Natureza da alteração                                      |
|---------------|-----------------------------------------------------------|------------------------------------------------------------|
| SAP_Operador  | `modules/sap/factories/endActivityDialogSingleton.py`     | Corrige bug do singleton que cacheava `activeObs=False`    |
| SAP_Operador  | `modules/sap/controllers/remoteSapCtrl.py`                | Inclui `tipo_etapa_id=4` e passa `stepTypeId` ao dialog    |
| SAP_Operador  | `modules/sap/factories/guiFactory.py`                     | Repassa `stepTypeId` para o singleton                      |
| SAP_Operador  | `modules/sap/widgets/endActivityDialog.py`                | Usa `stepTypeId` para label, resize e destino da observação|
